### PR TITLE
Reorganize and Add Netlify Badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Community Website 
 Built By community for the community
+<br>
+<br>
+[![Netlify Status](https://api.netlify.com/api/v1/badges/ac823357-156c-4876-97b3-44f3d0bdb763/deploy-status)](https://app.netlify.com/sites/studentzynergy/deploys)
+![Deployment](https://github.com/solve-ease/community-website/actions/workflows/deployment.yml/badge.svg).
+![Greetings](https://github.com/solve-ease/community-website/actions/workflows/greetings.yml/badge.svg)
+![CodeQL](https://github.com/solve-ease/community-website/actions/workflows/codeql.yml/badge.svg)
+![Dependencies](https://github.com/solve-ease/community-website/actions/workflows/dependency-review.yml/badge.svg)
+![Issue label](https://github.com/solve-ease/community-website/actions/workflows/issue-label.yml/badge.svg)
+![PR label](https://github.com/solve-ease/community-website/actions/workflows/pr-label.yml/badge.svg)
+
+<br>
+<br>
 
 <center>
 <img src = "https://readme-typing-svg.herokuapp.com/?color=red&size=40&width=1200&height=80&lines=StudentZynergy:%20Unleashing%20Innovative%20Collaboration"> 
@@ -17,12 +29,6 @@ Built By community for the community
 ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/solve-ease/community-website?style=badge&color=green)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/solve-ease/community-website?style=badge&color=green)
 ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed/solve-ease/community-website?style=badge&color=green)
-![Deployment](https://github.com/solve-ease/community-website/actions/workflows/deployment.yml/badge.svg).
-![Greetings](https://github.com/solve-ease/community-website/actions/workflows/greetings.yml/badge.svg)
-![CodeQL](https://github.com/solve-ease/community-website/actions/workflows/codeql.yml/badge.svg)
-![Dependencies](https://github.com/solve-ease/community-website/actions/workflows/dependency-review.yml/badge.svg)
-![Issue label](https://github.com/solve-ease/community-website/actions/workflows/issue-label.yml/badge.svg)
-![PR label](https://github.com/solve-ease/community-website/actions/workflows/pr-label.yml/badge.svg)
 
 
 ## Description


### PR DESCRIPTION
This PR aims to improve the readability and organization of the README.md file by repositioning several GitHub action badges. Additionally, it includes the addition of a new Netlify status badge. Specifically, it moves the badges related to deployment, greetings, CodeQL, dependency review, issue labeling, and PR labeling immediately after the Netlify badges.

Title:
Reorganize and Add Netlify Badge to README.md

Description:
This PR reorganizes several GitHub action badges in the README.md file for better readability and visibility. It also adds a new Netlify status badge to the top section.

Related Issue:
N/A

Changes Made:
#change 1
Added a new Netlify status badge:
[![Netlify Status](https://api.netlify.com/api/v1/badges/ac823357-156c-4876-97b3-44f3d0bdb763/deploy-status)](https://app.netlify.com/sites/studentzynergy/deploys)
#change 2
Moved the following badges directly after the Netlify badges:
![Deployment](https://github.com/solve-ease/community-website/actions/workflows/deployment.yml/badge.svg)
![Greetings](https://github.com/solve-ease/community-website/actions/workflows/greetings.yml/badge.svg)
![CodeQL](https://github.com/solve-ease/community-website/actions/workflows/codeql.yml/badge.svg)
![Dependencies](https://github.com/solve-ease/community-website/actions/workflows/dependency-review.yml/badge.svg)
![Issue label](https://github.com/solve-ease/community-website/actions/workflows/issue-label.yml/badge.svg)
![PR label](https://github.com/solve-ease/community-website/actions/workflows/pr-label.yml/badge.svg)


Checklist:
 My code follows the code style of this project
 I have performed a self-review of my code
 I have commented my code, particularly in hard-to-understand areas
 I have made corresponding changes to the documentation
 My changes generate no new warnings
 I have added tests that prove my fix is effective or that my feature works
 New and existing unit tests pass locally with my changes

Additional Information:
N/A

